### PR TITLE
 Importing directly from the source

### DIFF
--- a/cmd/sqlabble/generator/converter.go
+++ b/cmd/sqlabble/generator/converter.go
@@ -226,7 +226,7 @@ type Scanner interface {
 	}
 
 	conf := &types.Config{
-		Importer: importer.Default(),
+		Importer: importer.For("source", nil),
 	}
 	info := &types.Info{
 		Defs: map[*ast.Ident]types.Object{},


### PR DESCRIPTION
`importer.Default()` doesn't support packages under vendor directory, so use `importer.For("source", nil)`